### PR TITLE
Add support for using public docker images

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -68,7 +68,7 @@ class AppsController < ApplicationController
       :name,
       :description,
       :image_source,
-      :ecr_repository,
+      :repository_name,
       :job_spec,
       :auto_deploy,
       :auto_deploy_branch

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -67,6 +67,7 @@ class AppsController < ApplicationController
     params.require(:app).permit(
       :name,
       :description,
+      :image_source,
       :ecr_repository,
       :job_spec,
       :auto_deploy,

--- a/app/javascript/application/index.ts
+++ b/app/javascript/application/index.ts
@@ -6,6 +6,8 @@ Rails.start();
 
 import hljs from 'highlight.js';
 
+import 'bootstrap.native/dist/bootstrap-native-v4';
+
 document.addEventListener('turbolinks:load', () => {
   document.querySelectorAll('pre code').forEach((block) => hljs.highlightBlock(block));
 });

--- a/app/javascript/application/index.ts
+++ b/app/javascript/application/index.ts
@@ -6,10 +6,11 @@ Rails.start();
 
 import hljs from 'highlight.js';
 
-import 'bootstrap.native/dist/bootstrap-native-v4';
+import bootstrap from 'bootstrap.native';
 
 document.addEventListener('turbolinks:load', () => {
   document.querySelectorAll('pre code').forEach((block) => hljs.highlightBlock(block));
+  document.querySelectorAll('[data-toggle="buttons"]').forEach((button) => new bootstrap.Button(button));
 });
 
 import ImageSelector from 'components/ImageSelector';

--- a/app/javascript/application/index.ts
+++ b/app/javascript/application/index.ts
@@ -19,3 +19,23 @@ import StatusBadge from 'components/StatusBadge';
 
 import WebpackerReact from 'webpacker-react';
 WebpackerReact.setup({ StatusBadge, ImageSelector, NomadStatus });
+
+document.addEventListener('turbolinks:load', () => {
+  document.querySelectorAll('.auto-deploy-field').forEach((field) => {
+    const selectors = Array.from(document.querySelectorAll('.app-image-source-selector input')) as HTMLInputElement[];
+    if (!selectors.length) return;
+
+    const ecrSelector = selectors.find((s) => s.value === 'ecr');
+
+    const updater = () => {
+      if (ecrSelector && ecrSelector.checked) {
+        field.classList.remove('hidden');
+      } else {
+        field.classList.add('hidden');
+      }
+    };
+
+    updater();
+    selectors.forEach((selector) => selector.addEventListener('click', updater));
+  });
+});

--- a/app/javascript/components/ImageSelector/Image.ts
+++ b/app/javascript/components/ImageSelector/Image.ts
@@ -2,14 +2,14 @@ import filesize from 'filesize';
 import Moment from 'moment';
 
 export default class Image {
-  public digest: string;
-  public pushedAt: Moment.Moment;
+  public id: string;
+  public timestamp: Moment.Moment;
   public size: number;
   public tags: string[];
 
   constructor(json: { [s: string]: any }) {
-    this.digest = json.digest;
-    this.pushedAt = Moment(json.pushed_at);
+    this.id = json.id;
+    this.timestamp = Moment(json.timestamp);
     this.size = json.size;
     this.tags = json.tags;
   }

--- a/app/javascript/components/ImageSelector/ImageList.tsx
+++ b/app/javascript/components/ImageSelector/ImageList.tsx
@@ -53,7 +53,7 @@ export default class ImageList extends React.Component<ImageListProps, ImageList
   }
 
   private get errorMessage() {
-    return <div className='ImageList-errorMessage alert alert-danger'>Error fetching data from AWS.</div>;
+    return <div className='ImageList-errorMessage alert alert-danger'>Error fetching data.</div>;
   }
 
   private get emptyRow() {
@@ -66,14 +66,14 @@ export default class ImageList extends React.Component<ImageListProps, ImageList
 
   private get imageRows() {
     return this.state.images.map((image) => {
-      const isActive = !!(this.props.selectedImage && this.props.selectedImage.digest === image.digest);
+      const isActive = !!(this.props.selectedImage && this.props.selectedImage.id === image.id);
       const className = `list-group-item flex-column align-items-start ${ isActive ? 'active' : 'not-active'}`;
 
       return (
-        <div className={ className } key={ image.digest } onClick={ () => this.props.onSelect(image) }>
+        <div className={ className } key={ image.id } onClick={ () => this.props.onSelect(image) }>
           <div className='d-flex w-100 justify-content-between align-items-center mb-2'>
             <span className='tags'>{ this.taggify(image.tags, isActive) }</span>
-            <small>{ image.pushedAt.locale('en-gb').calendar() }</small>
+            <small>{ image.timestamp.locale('en-gb').calendar() }</small>
           </div>
           <small>{ image.fileSize }</small>
         </div>

--- a/app/javascript/styles/index.sass
+++ b/app/javascript/styles/index.sass
@@ -65,8 +65,12 @@ h5
       border-color: #28a745 !important
       color: white !important
 
+.auto-deploy-field
+  &.hidden
+    display: none
 .auto-deploy-input
   display: none
+  padding-top: 0.5rem
   .form-check-input#app_auto_deploy:checked ~ &
     display: block
 

--- a/app/javascript/styles/index.sass
+++ b/app/javascript/styles/index.sass
@@ -58,6 +58,12 @@ h5
   &.required label:after
     content: " *"
     color: red
+  .btn-group-toggle
+    display: block
+    .active
+      background-color: #28a745 !important
+      border-color: #28a745 !important
+      color: white !important
 
 .auto-deploy-input
   display: none

--- a/app/javascript/typings/bootstrap.d.ts
+++ b/app/javascript/typings/bootstrap.d.ts
@@ -1,0 +1,1 @@
+declare module 'bootstrap.native';

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -2,6 +2,7 @@ class App < ApplicationRecord
   NAME_FORMAT = /\A[a-z0-9\-]+\Z/
 
   validates :name, uniqueness: true, presence: true, format: { with: NAME_FORMAT }
+  validates :image_source, inclusion: { in: %w[dockerhub ecr] }
   validates :ecr_repository, presence: true
   validates :job_spec, presence: true
   validate :check_job_spec_is_json

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -3,7 +3,7 @@ class App < ApplicationRecord
 
   validates :name, uniqueness: true, presence: true, format: { with: NAME_FORMAT }
   validates :image_source, inclusion: { in: %w[dockerhub ecr] }
-  validates :ecr_repository, presence: true
+  validates :repository_name, presence: true
   validates :job_spec, presence: true
   validate :check_job_spec_is_json
 

--- a/app/models/app_deployment.rb
+++ b/app/models/app_deployment.rb
@@ -14,14 +14,23 @@ class AppDeployment
   private
 
   def job_spec
-    @job_spec ||= JobSpec.new(app, image_uri)
+    @job_spec ||= JobSpec.new(app, image_name)
   end
 
-  def image_uri
-    ENV.fetch('ECR_BASE') + '/' + app.repository_name + ':' + tag
+  def image_name
+    case app.image_source
+    when 'ecr'
+      "#{ecr_base}/#{app.repository_name}:#{tag}"
+    when 'dockerhub'
+      "#{app.repository_name}:#{tag}"
+    end
   end
 
   def nomad_client
     @nomad_client ||= Nomad::Client.new(address: ENV.fetch('NOMAD_API_URI'))
+  end
+
+  def ecr_base
+    ENV.fetch('ECR_BASE')
   end
 end

--- a/app/models/app_deployment.rb
+++ b/app/models/app_deployment.rb
@@ -18,7 +18,7 @@ class AppDeployment
   end
 
   def image_uri
-    ENV.fetch('ECR_BASE') + '/' + app.ecr_repository + ':' + tag
+    ENV.fetch('ECR_BASE') + '/' + app.repository_name + ':' + tag
   end
 
   def nomad_client

--- a/app/models/app_image_list.rb
+++ b/app/models/app_image_list.rb
@@ -28,7 +28,7 @@ class AppImageList
   # TODO: should we consider pagination? This will return a maximum of 100
   # images. Maybe we don't care?
   def ecr_images
-    ecr_client.describe_images(repository_name: app.ecr_repository).image_details
+    ecr_client.describe_images(repository_name: app.repository_name).image_details
   rescue Aws::ECR::Errors::RepositoryNotFoundException
     []
   end

--- a/app/models/app_image_list.rb
+++ b/app/models/app_image_list.rb
@@ -2,22 +2,52 @@ class AppImageList
   attr_reader :app
   private :app
 
+  ARCH = 'amd64'.freeze
+  OS = 'linux'.freeze
+
   def initialize(app)
     @app = app
   end
 
   def as_json(*)
-    ecr_images.map(&method(:image_data)).sort_by { |i| i[:pushed_at] }.reverse
+    case app.image_source
+    when 'ecr'
+      ecr_image_list
+    when 'dockerhub'
+      dockerhub_image_list
+    else
+      []
+    end
   end
 
   private
 
-  def image_data(image)
+  def ecr_image_list
+    ecr_images.map(&method(:ecr_image_data)).sort_by { |i| i[:timestamp] }.reverse
+  end
+
+  def dockerhub_image_list
+    dockerhub_tags.map(&method(:dockerhub_tag_to_image)).compact.sort_by { |i| i[:timestamp] }.reverse
+  end
+
+  def ecr_image_data(image)
     {
-      digest: image.image_digest,
+      id: image.image_digest,
       tags: image.image_tags || [],
       size: image.image_size_in_bytes,
-      pushed_at: image.image_pushed_at
+      timestamp: image.image_pushed_at
+    }
+  end
+
+  def dockerhub_tag_to_image(tag)
+    image = tag['images'].find { |i| i['architecture'] == ARCH && i['os'] == OS }
+    return unless image
+
+    {
+      id: tag['id'],
+      tags: [tag['name']],
+      size: image['size'],
+      timestamp: Time.parse(tag['last_updated'])
     }
   end
 
@@ -31,5 +61,14 @@ class AppImageList
     ecr_client.describe_images(repository_name: app.repository_name).image_details
   rescue Aws::ECR::Errors::RepositoryNotFoundException
     []
+  end
+
+  # TODO: also consider paginating this
+  def dockerhub_tags
+    HTTP.get(dockerhub_url).parse['results']
+  end
+
+  def dockerhub_url
+    "https://hub.docker.com/v2/repositories/#{app.repository_name}/tags/"
   end
 end

--- a/app/models/job_spec.rb
+++ b/app/models/job_spec.rb
@@ -1,10 +1,10 @@
 class JobSpec
-  attr_reader :app, :docker_image_uri
-  private :app, :docker_image_uri
+  attr_reader :app, :docker_image_name
+  private :app, :docker_image_name
 
-  def initialize(app, docker_image_uri)
+  def initialize(app, docker_image_name)
     @app = app
-    @docker_image_uri = docker_image_uri
+    @docker_image_name = docker_image_name
   end
 
   def as_json(*)
@@ -13,7 +13,7 @@ class JobSpec
     base[:ID] = app.name
     base[:TaskGroups].each do |task_group|
       task_group[:Tasks].each do |task|
-        task[:Config][:image] = docker_image_uri
+        task[:Config][:image] = docker_image_name
       end
     end
 

--- a/app/views/apps/_form.html.haml
+++ b/app/views/apps/_form.html.haml
@@ -12,6 +12,18 @@
     = f.text_area :description, class: 'form-control'
     %small.form-text.text-muted A short description of this app's purpose.
 
+  .form-group
+    = f.label :image_source, 'Image source'
+    .btn-group.btn-group-toggle{ data: { toggle: :buttons} }
+      = f.label :image_source_dockerhub, class: 'btn btn-light' do
+        = f.radio_button :image_source, :dockerhub
+        Docker Hub
+      = f.label :image_source_ecr, class: 'btn btn-light' do
+        = f.radio_button :image_source, :ecr
+        ECR
+
+    %small.form-text.text-muted Select whether images will be sourced from Docker Hub or a private ECR repository.
+
   .form-group.required
     = f.label :ecr_repository, "ECR repository"
     = f.text_field :ecr_repository, class: 'form-control'

--- a/app/views/apps/_form.html.haml
+++ b/app/views/apps/_form.html.haml
@@ -12,7 +12,7 @@
     = f.text_area :description, class: 'form-control'
     %small.form-text.text-muted A short description of this app's purpose.
 
-  .form-group
+  .form-group.app-image-source-selector
     = f.label :image_source, 'Image source'
     .btn-group.btn-group-toggle{ data: { toggle: :buttons} }
       = f.label :image_source_dockerhub, class: 'btn btn-light' do
@@ -29,13 +29,14 @@
     = f.text_field :repository_name, class: 'form-control'
     %small.form-text.text-muted Name of the repository to use for this app, including namespace (e.g. 'f1000-collector', 'library/memcached')
 
-  .form-group.form-check
-    = f.check_box :auto_deploy, class: 'form-check-input'
-    = f.label :auto_deploy, "Auto-deploy builds"
-    .div.auto-deploy-input
-      = f.text_field :auto_deploy_branch, class: 'form-control', placholder: 'Branch to automatically deploy.'
+  .form-group.auto-deploy-field
+    .form-group.form-check
+      = f.check_box :auto_deploy, class: 'form-check-input'
+      = f.label :auto_deploy, "Auto-deploy new ECR images from branch"
+      %small.form-text.text-muted Tick to automatically deploy this application when new images are pushed to ECR from the specified branch.
+      .auto-deploy-input.form-group
+        = f.text_field :auto_deploy_branch, class: 'form-control', placeholder: 'Branch to automatically deploy.'
 
-    %small.form-text.text-muted Tick to automatically deploy builds on a specified branch.
 
   .form-group.required
     = f.label :job_spec, 'JSON job spec'

--- a/app/views/apps/_form.html.haml
+++ b/app/views/apps/_form.html.haml
@@ -1,0 +1,35 @@
+= form_for @app do |f|
+  = form_errors(@app)
+
+  - unless @app.persisted?
+    .form-group.required
+      = f.label :name
+      = f.text_field :name, class: 'form-control'
+      %small.form-text.text-muted App names can contain lowercase alphanumerics and dashes only.
+
+  .form-group
+    = f.label :description
+    = f.text_area :description, class: 'form-control'
+    %small.form-text.text-muted A short description of this app's purpose.
+
+  .form-group.required
+    = f.label :ecr_repository, "ECR repository"
+    = f.text_field :ecr_repository, class: 'form-control'
+    %small.form-text.text-muted Amazon ECR repository to use for this app (e.g. 'f1000-collector')
+
+  .form-group.form-check
+    = f.check_box :auto_deploy, class: 'form-check-input'
+    = f.label :auto_deploy, "Auto-deploy builds"
+    .div.auto-deploy-input
+      = f.text_field :auto_deploy_branch, class: 'form-control', placholder: 'Branch to automatically deploy.'
+
+    %small.form-text.text-muted Tick to automatically deploy builds on a specified branch.
+
+  .form-group.required
+    = f.label :job_spec, 'JSON job spec'
+    = f.text_area :job_spec, class: 'form-control text-monospace', rows: 20
+    %small.form-text.text-muted Job spec for this application. The job ID and Docker image specification will be overriden.
+
+  .form-group.buttons
+    = f.submit class: 'btn btn-primary'
+    = link_to 'Cancel', apps_path, class: 'btn btn-secondary'

--- a/app/views/apps/_form.html.haml
+++ b/app/views/apps/_form.html.haml
@@ -25,9 +25,9 @@
     %small.form-text.text-muted Select whether images will be sourced from Docker Hub or a private ECR repository.
 
   .form-group.required
-    = f.label :ecr_repository, "ECR repository"
-    = f.text_field :ecr_repository, class: 'form-control'
-    %small.form-text.text-muted Amazon ECR repository to use for this app (e.g. 'f1000-collector')
+    = f.label :repository_name, "Repository name"
+    = f.text_field :repository_name, class: 'form-control'
+    %small.form-text.text-muted Name of the repository to use for this app, including namespace (e.g. 'f1000-collector', 'library/memcached')
 
   .form-group.form-check
     = f.check_box :auto_deploy, class: 'form-check-input'

--- a/app/views/apps/deploy.html.haml
+++ b/app/views/apps/deploy.html.haml
@@ -2,4 +2,4 @@
 
 .container
   .tab-content
-    = react_component('ImageSelector', imageListEndpoint: api_app_images_path(@app), deployEndpoint: api_app_deploy_path(@app), repositoryName: @app.ecr_repository)
+    = react_component('ImageSelector', imageListEndpoint: api_app_images_path(@app), deployEndpoint: api_app_deploy_path(@app), repositoryName: @app.repository_name)

--- a/app/views/apps/edit.html.haml
+++ b/app/views/apps/edit.html.haml
@@ -2,32 +2,4 @@
 
 .container
   .tab-content
-    = form_for @app do |f|
-      = form_errors(@app)
-
-      .form-group
-        = f.label :description
-        = f.text_area :description, class: 'form-control'
-        %small.form-text.text-muted A short description of this app's purpose.
-
-      .form-group.required
-        = f.label :ecr_repository, "ECR repository"
-        = f.text_field :ecr_repository, class: 'form-control'
-        %small.form-text.text-muted Amazon ECR repository to use for this app (e.g. 'f1000-collector')
-
-      .form-group.form-check
-        = f.check_box :auto_deploy, class: 'form-check-input'
-        = f.label :auto_deploy, "Auto-deploy builds"
-        .div.auto-deploy-input
-          = f.text_field :auto_deploy_branch, class: 'form-control', placholder: 'Branch to automatically deploy.'
-
-        %small.form-text.text-muted Tick to automatically deploy builds on a specified branch.
-
-      .form-group.required
-        = f.label :job_spec, 'JSON job spec'
-        = f.text_area :job_spec, class: 'form-control text-monospace', rows: 20
-        %small.form-text.text-muted Job spec for this application. The job ID and Docker image specification will be overriden.
-
-      .form-group.buttons
-        = f.submit class: 'btn btn-primary'
-        = link_to 'Cancel', apps_path, class: 'btn btn-secondary'
+    = render 'form'

--- a/app/views/apps/new.html.haml
+++ b/app/views/apps/new.html.haml
@@ -6,37 +6,4 @@
   = link_to '← Return to apps', apps_path, class: 'btn btn-secondary'
 
 .container
-  = form_for @app do |f|
-    = form_errors(@app)
-
-    .form-group.required
-      = f.label :name
-      = f.text_field :name, class: 'form-control'
-      %small.form-text.text-muted App names can contain lowercase alphanumerics and dashes only.
-
-    .form-group
-      = f.label :description
-      = f.text_area :description, class: 'form-control'
-      %small.form-text.text-muted A short description of this app's purpose.
-
-    .form-group.required
-      = f.label :ecr_repository, "ECR repository"
-      = f.text_field :ecr_repository, class: 'form-control'
-      %small.form-text.text-muted Amazon ECR repository to use for this app (e.g. 'f1000-collector')
-
-    .form-group.form-check
-      = f.check_box :auto_deploy, class: 'form-check-input'
-      = f.label :auto_deploy, "Auto-deploy builds"
-      .div.auto-deploy-input
-        = f.text_field :auto_deploy_branch, class: 'form-control', placholder: 'Branch to automatically deploy.'
-
-      %small.form-text.text-muted Tick to automatically deploy builds on a specified branch.
-
-    .form-group.required
-      = f.label :job_spec, 'JSON job spec'
-      = f.text_area :job_spec, class: 'form-control text-monospace', rows: 20
-      %small.form-text.text-muted Job spec for this application. The job ID and Docker image specification will be overriden.
-
-    .form-group.buttons
-      = f.submit class: 'btn btn-primary'
-      = link_to 'Cancel', apps_path, class: 'btn btn-secondary'
+  = render 'form'

--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -10,8 +10,8 @@
         %dd= @app.description
       %dt Image source
       %dd= @app.image_source
-      %dt ECR repository
-      %dd= @app.ecr_repository
+      %dt Repository name
+      %dd= @app.repository_name
       %dt Created at
       %dd #{ @app.created_at } (#{ time_ago_in_words(@app.created_at) } ago)
       %dt Last updated

--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -8,6 +8,8 @@
       - if @app.description.present?
         %dt Description
         %dd= @app.description
+      %dt Image source
+      %dd= @app.image_source
       %dt ECR repository
       %dd= @app.ecr_repository
       %dt Created at

--- a/db/migrate/20180710104439_add_app_image_source_field.rb
+++ b/db/migrate/20180710104439_add_app_image_source_field.rb
@@ -1,0 +1,5 @@
+class AddAppImageSourceField < ActiveRecord::Migration[5.1]
+  def change
+    add_column :apps, :image_source, :text, null: false, default: :ecr
+  end
+end

--- a/db/migrate/20180710112004_rename_ecr_repository.rb
+++ b/db/migrate/20180710112004_rename_ecr_repository.rb
@@ -1,0 +1,5 @@
+class RenameEcrRepository < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :apps, :ecr_repository, :repository_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180710104439) do
+ActiveRecord::Schema.define(version: 20180710112004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 20180710104439) do
   create_table "apps", force: :cascade do |t|
     t.text "name", null: false
     t.text "description"
-    t.text "ecr_repository", null: false
+    t.text "repository_name", null: false
     t.text "env_template"
     t.boolean "auto_deploy", default: false
     t.text "auto_deploy_branch", default: "master"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180330214245) do
+ActiveRecord::Schema.define(version: 20180710104439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20180330214245) do
     t.text "job_spec", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "image_source", default: "ecr", null: false
     t.index ["name"], name: "index_apps_on_name", unique: true
   end
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-react": "^6.24.1",
     "bootstrap": "^4.0.0",
+    "bootstrap.native": "^2.0.23",
     "caniuse-lite": "^1.0.30000862",
     "eslint": "^4.16.0",
     "eslint-plugin-react": "^7.6.0",

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe App do
   def app_named(name)
-    App.create(name: name, ecr_repository: 'test', job_spec: '{}')
+    App.create(name: name, repository_name: 'test', job_spec: '{}')
   end
 
   describe 'name' do

--- a/yarn.lock
+++ b/yarn.lock
@@ -1417,6 +1417,10 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
+bootstrap.native@^2.0.23:
+  version "2.0.23"
+  resolved "https://registry.yarnpkg.com/bootstrap.native/-/bootstrap.native-2.0.23.tgz#e505c93740db9d94994fdf075834f992512e72c1"
+
 bootstrap@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.1.tgz#3aec85000fa619085da8d2e4983dfd67cf2114cb"


### PR DESCRIPTION
This change adds basic support for using images from the public Docker Hub repo instead of the private ECR repo. This is useful for deploying open-source applications like RockSteady itself, or any of the many apps and services which are already available from the public repo!

The main change is the addition of an `image_source` field on the app record, which allows users to choose between `dockerhub` or `ecr`. We then use this to fetch our list of images from the correct endpoint, and to generate the correct docker image name when deploying. There is some additional support for around this to build a usable UI for toggling this feature.