### PR TITLE
Upgrade rack and loofah

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
@@ -140,7 +140,7 @@ GEM
     minitest (5.11.3)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nomad (0.1.0)
     notiffany (0.1.1)
@@ -158,7 +158,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-proxy (0.6.4)
       rack
     rack-test (1.0.0)
@@ -291,4 +291,4 @@ DEPENDENCIES
   webpacker-react
 
 BUNDLED WITH
-   1.16.1
+   1.16.4


### PR DESCRIPTION
Fixes vulnerability issues by upgrading the mentioned gems.
Addresses CVE-2018-16470, CVE-2018-16471 and CVE-2018-16468.