### PR TITLE
Support Docker tags with periods

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+DOCKER_TAG = /\w[\w.-]{,127}/.freeze
+
 Rails.application.routes.draw do
   root to: redirect('/apps')
 
@@ -13,7 +15,7 @@ Rails.application.routes.draw do
     get 'app/:id/status' => 'app#status', :as => :app_status
     get 'app/:id/nomad_status' => 'app#nomad_status', :as => :app_nomad_status
     get 'app/:id/images' => 'app#images', :as => :app_images
-    post 'app/:id/deploy/(:tag)' => 'app#deploy', :as => :app_deploy
+    post 'app/:id/deploy/(:tag)' => 'app#deploy', :as => :app_deploy, :tag => DOCKER_TAG
   end
 
   post '/webhook/:app' => 'webhook#handle'

--- a/spec/routing/api_routing_spec.rb
+++ b/spec/routing/api_routing_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'API routes' do
+  it 'routes alphanumeric tags for app deployment' do
+    expect(post: '/api/app/1/deploy/latest').to be_routable
+  end
+
+  it 'routes valid non-alphanumeric tags for app deployment' do
+    expect(post: '/api/app/1/deploy/v1.0.0-BETA_r1').to be_routable
+  end
+
+  it 'does not route invalid tags longer than 128 characters for app deployment' do
+    expect(post: '/api/app/1/deploy/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa').not_to be_routable
+  end
+
+  it 'does not route invalid tags starting with a period for app deployment' do
+    expect(post: '/api/app/1/deploy/.invalid').not_to be_routable
+  end
+
+  it 'does not route invalid tags starting with a dash for app deployment' do
+    expect(post: '/api/app/1/deploy/-invalid').not_to be_routable
+  end
+end


### PR DESCRIPTION
> A tag name must be valid ASCII and may contain lowercase and uppercase
> letters, digits, underscores, periods and dashes. A tag name may not
> start with a period or a dash and may contain a maximum of 128
> characters.

-- https://docs.docker.com/engine/reference/commandline/tag/#extended-description