### PR TITLE
Support Auto deploy on multiple apps based on repository

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,2 @@
 NOMAD_API_URI=http://localhost:4646
+ECR_BASE=example.com

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -9,4 +9,13 @@ class App < ApplicationRecord
   def to_param
     name
   end
+
+  def trigger_auto_deploy(notification)
+    return unless auto_deploy? &&
+      auto_deploy_branch == notification.branch &&
+      notification.finished? &&
+      notification.success?
+
+    AppDeployment.new(self, "build-#{notification.build_number}").deploy!
+  end
 end

--- a/app/models/circle_build_notification.rb
+++ b/app/models/circle_build_notification.rb
@@ -21,4 +21,8 @@ class CircleBuildNotification
   def branch
     params[:branch]
   end
+
+  def repository_name
+    params[:repository_name]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
     post 'app/:id/deploy/(:tag)' => 'app#deploy', :as => :app_deploy, :tag => DOCKER_TAG
   end
 
-  post '/webhook/:app' => 'webhook#handle'
+  post '/webhook' => 'webhook#deploy'
+  post '/webhook/:app' => 'webhook#deploy_app'
+
 
   get '/ping' => proc { [200, {}, ['']] }
 end

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -1,8 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe App do
-  def app_named(name)
-    App.create(name: name, repository_name: 'test', job_spec: 'job {}')
+  def app_named(name, options = {})
+    App.create(
+      { name: name, repository_name: 'test', job_spec: 'job {}' }.merge(options)
+    )
+  end
+
+  def notification_for(branch)
+    CircleBuildNotification.new(
+      outcome: 'success',
+      lifecycle: 'finished',
+      build_num: '27',
+      branch: branch,
+      repository_name: 'foo-bar'
+    )
   end
 
   describe 'name' do
@@ -26,6 +38,37 @@ RSpec.describe App do
       app_named('test-app')
 
       expect(app_named('test-app').errors.messages[:name]).to include('has already been taken')
+    end
+  end
+
+  describe '#trigger_auto_deploy' do
+    it 'returns nil if app is autodeploy disabled' do
+      notification = notification_for('master')
+
+      expect(app_named('no-auto-deploy').trigger_auto_deploy(notification)).to be_nil
+    end
+
+    it 'returns nil if app auto deploy branch does not match notification branch' do
+      notification = notification_for('staging')
+
+      expect(
+        app_named('no-auto-deploy', auto_deploy_branch: 'master', auto_deploy: true).trigger_auto_deploy(notification)
+      ).to be_nil
+    end
+
+    it 'creates a job in nomad if an app is deployable' do
+      notification = notification_for('master')
+
+      request = stub_request(:post, /jobs/).to_return(status: 200, body: '{"TaskGroups":[]}', headers: { 'Content-Type' => 'application/json' })
+      app_named('no-auto-deploy', auto_deploy_branch: 'master', auto_deploy: true).trigger_auto_deploy(notification)
+      expect(request).to have_been_made.at_least_once
+    end
+
+    it 'raises an error if job creation fails' do
+      notification = notification_for('master')
+
+      stub_request(:post, /jobs/).to_timeout
+      expect { app_named('no-auto-deploy', auto_deploy_branch: 'master', auto_deploy: true).trigger_auto_deploy(notification) }.to raise_error(HTTP::TimeoutError)
     end
   end
 end


### PR DESCRIPTION
When apps share a repository name, add ability to mass deploy to all
apps under the endpoint "/webhook". We still maintain the endpoint for a
single app to be deployed under "/webhook/app"

paired with @mudge