### PR TITLE
Do not return a 404 if no apps are auto deployable

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -4,20 +4,16 @@ class WebhookController < ActionController::API
 
     if autodeployed_apps.any?
       head 200
-    elsif apps.any?
-      head 204
     else
-      head 404
+      head 204
     end
   end
 
   def deploy_app
     if app.trigger_auto_deploy(notification)
       head 200
-    elsif app
-      head 204
     else
-      head 404
+      head 204
     end
   end
 


### PR DESCRIPTION
This is tied to a CircleCI build, which will fail if no apps are
configured in the environment. Do not return a 404 to ensure a green
build