### PR TITLE
Return all ECR images, not just the first page

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,21 @@
-node_modules
+# Ignore bundler config.
+/.bundle
+
+# Ignore the default SQLite database.
+/db/*.sqlite3
+/db/*.sqlite3-journal
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+/node_modules
+/yarn-error.log
+
+.byebug_history
+/public/packs
+/node_modules
+
+spec/examples.txt

--- a/spec/models/app_image_list_spec.rb
+++ b/spec/models/app_image_list_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe AppImageList do
+  describe '#as_json' do
+    it 'orders images with latest pushed first' do
+      stub_request(:post, 'https://ecr.eu-west-1.amazonaws.com/').to_return(body: <<~JSON)
+        {
+           "imageDetails": [
+              {
+                 "imageDigest": "decafbad",
+                 "imagePushedAt": 1,
+                 "imageSizeInBytes": 12,
+                 "imageTags": [ "oldest" ],
+                 "registryId": "test-job",
+                 "repositoryName": "test-job"
+              },
+              {
+                 "imageDigest": "decafbad",
+                 "imagePushedAt": 3,
+                 "imageSizeInBytes": 12,
+                 "imageTags": [ "latest" ],
+                 "registryId": "test-job",
+                 "repositoryName": "test-job"
+              },
+              {
+                 "imageDigest": "decafbad",
+                 "imagePushedAt": 2,
+                 "imageSizeInBytes": 12,
+                 "imageTags": [ "old" ],
+                 "registryId": "test-job",
+                 "repositoryName": "test-job"
+              }
+           ],
+           "nextToken": null
+        }
+      JSON
+      app = App.new(repository_name: 'test-job')
+      json = described_class.new(app).as_json
+
+      expect(json.first).to include(tags: ['latest'])
+    end
+  end
+end


### PR DESCRIPTION
Unfortunately, ECR images do not have a guaranteed sort order and we've seen the latest image actually appear on the _second_ page of the DescribeImages response. For now, collect _all_ images for a repository and rely on limiting the number of available images at the ECR side.

As we're now potentially loading huge numbers of images, use destructive array operations to convert them into JSON and sort them.