### PR TITLE
Group apps by repositories

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -15,7 +15,7 @@ rules:
   empty-line-between-blocks: 0
   empty-args:
     - 2
-    -r
+    -
       include: false
   indentation: 0
   leading-zero:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,12 +136,12 @@ GEM
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
     mini_mime (1.0.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
     nomad (0.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -291,4 +291,4 @@ DEPENDENCIES
   webpacker-react
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -1,6 +1,6 @@
 class AppsController < ApplicationController
   def index
-    @apps = App.all.order(:name)
+    @repos = App.all.group_by(&:repository_name).sort_by { |repo_name, _| repo_name }
   end
 
   def show

--- a/app/javascript/application/index.ts
+++ b/app/javascript/application/index.ts
@@ -36,3 +36,22 @@ document.addEventListener('turbolinks:load', () => {
     selectors.forEach((selector) => selector.addEventListener('click', updater));
   });
 });
+
+document.addEventListener('turbolinks:load', () => {
+  const coll = document.getElementsByClassName('collapsible');
+  for (let i = 0; i < coll.length; i++) {
+    coll[i].addEventListener('click', (event) => {
+      if (event && event.currentTarget) {
+        let block = event.currentTarget as Element;
+        block.classList.toggle('active');
+
+        let content = block.nextElementSibling as HTMLElement;
+        if (content.style.maxHeight) {
+          content.style.maxHeight = null;
+        } else {
+          content.style.maxHeight = content.scrollHeight + "px";
+        }
+      }
+    });
+  }
+});

--- a/app/javascript/styles/index.sass
+++ b/app/javascript/styles/index.sass
@@ -180,3 +180,28 @@ pre
   .hljs
     border-radius: 5px
     padding: 2rem
+
+.collapsible
+  cursor: pointer
+  .arrow:before
+    content: ' '
+    display: inline-block
+    border-top: 5px solid transparent
+    border-bottom: 5px solid transparent
+    border-left: 5px solid currentColor
+    vertical-align: middle
+    margin-right: .7rem
+
+  .arrow, .repo-name
+    float: left
+
+.collapsible.active .arrow
+  transform: rotate(90deg) translateX(6px) translateY(8px)
+
+.apps
+  width: auto
+
+.appscontent
+  max-height: 0
+  overflow: hidden
+  transition: max-height 0.2s ease-out

--- a/app/javascript/styles/index.sass
+++ b/app/javascript/styles/index.sass
@@ -14,8 +14,8 @@
   padding-bottom: 0
 
 .toolbar-container
-  background: #eee
   display: flex
+  background: #eee
   .breadcrumbs
     flex-grow: 1
     padding: 0.5rem
@@ -44,13 +44,12 @@ h5
   .badge
     margin-left: 1rem
 
-
 // Form style tweaks
 ////////////////////////////////////////////////////////////////////////////////
 
 .form-errors
-  padding: 1rem
   margin-bottom: 2rem
+  padding: 1rem
   strong
     display: block
     margin-bottom: 1rem
@@ -61,13 +60,13 @@ h5
   &.buttons
     margin-top: 2rem
   &.required label:after
-    content: " *"
     color: red
+    content: " *"
   .btn-group-toggle
     display: block
     .active
-      background-color: #28a745 !important
       border-color: #28a745 !important
+      background-color: #28a745 !important
       color: white !important
 
 .auto-deploy-field
@@ -78,7 +77,6 @@ h5
   padding-top: 0.5rem
   .form-check-input#app_auto_deploy:checked ~ &
     display: block
-
 
 // Tab and content styles
 ////////////////////////////////////////////////////////////////////////////////
@@ -98,7 +96,6 @@ h5
     display: inline
     margin-left: 1rem
 
-
 // Components
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -106,9 +103,9 @@ h5
   h4
     margin-bottom: 2rem
   .badge
+    display: inline
     margin-right: 1rem
     margin-bottom: 0.5rem
-    display: inline
   small
     white-space: nowrap
 
@@ -134,13 +131,12 @@ h5
       width: 50%
       width: 300px
       padding: 1rem
-      text-align: center
-      overflow-y: scroll
       transform: translate(-50%, -50%)
-      background: white
       border-radius: 5px
+      background: white
+      text-align: center
       z-index: 10001
-
+      overflow-y: scroll
 
 .NomadStatus
   dt
@@ -151,10 +147,10 @@ h5
     display: inline-block
     width: 1rem
     height: 1rem
-    background: #888
-    border-radius: 2px
     margin-right: 0.5rem
     margin-bottom: -2px
+    border-radius: 2px
+    background: #888
     &.complete
       background: #0D6426
     &.running
@@ -164,7 +160,6 @@ h5
     &.starting
       background: #007bff
 
-
 // Table customisations
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -172,39 +167,40 @@ table
   td.emptyMessage
     color: #888
 
-
 // Syntax highlighting
 ////////////////////////////////////////////////////////////////////////////////
 
 pre
   .hljs
-    border-radius: 5px
     padding: 2rem
+    border-radius: 5px
 
 // Collapsible repos
 ////////////////////////////////////////////////////////////////////////////////
 
 .collapsible
   cursor: pointer
-  .arrow:before
-    content: ' '
-    display: inline-block
-    border-top: 5px solid transparent
-    border-bottom: 5px solid transparent
-    border-left: 5px solid currentColor
-    vertical-align: middle
-    margin-right: .7rem
+  .arrow
+    &::before
+      display: inline-block
+      margin-right: 0.7rem
+      border-top: 5px solid transparent
+      border-bottom: 5px solid transparent
+      border-left: 5px solid currentColor
+      content: ' '
+      vertical-align: middle
+  .active
+    .arrow
+      transform: rotate(90deg) translateX(6px) translateY(8px)
 
-  .arrow, .repo-name
+  .arrow,
+  .repo-name
     float: left
-
-.collapsible.active .arrow
-  transform: rotate(90deg) translateX(6px) translateY(8px)
 
 .apps
   width: auto
 
 .appscontent
   max-height: 0
-  overflow: hidden
   transition: max-height 0.2s ease-out
+  overflow: hidden

--- a/app/javascript/styles/index.sass
+++ b/app/javascript/styles/index.sass
@@ -181,6 +181,9 @@ pre
     border-radius: 5px
     padding: 2rem
 
+// Collapsible repos
+////////////////////////////////////////////////////////////////////////////////
+
 .collapsible
   cursor: pointer
   .arrow:before

--- a/app/views/apps/index.html.haml
+++ b/app/views/apps/index.html.haml
@@ -15,7 +15,7 @@
           %h5.mb-1
             = repo_name
       .appscontent
-        - apps.each do |app|
+        - apps.sort_by { |app| app.name }.each do |app|
           %a.list-group-item.list-group-item-action.flex-column.align-items-start.ml-3.apps{ href: app_path(app) }
             .d-flex.w-100.justify-content-between
               %h5.mb-1

--- a/app/views/apps/index.html.haml
+++ b/app/views/apps/index.html.haml
@@ -6,14 +6,22 @@
 
 .container
   .list-group
-    - if @apps.length.zero?
+    - if @repos.length.zero?
       .list-group-item.list-group-item-light No apps are registered. #{ link_to "Create an app.", new_app_path }
-    - @apps.each do |app|
-      %a.list-group-item.list-group-item-action.flex-column.align-items-start{ href: app_path(app) }
-        .d-flex.w-100.justify-content-between
+    - @repos.each do |repo_name, apps|
+      .list-group-item.list-group-item-action.flex-column.align-items-start.collapsible
+        .arrow
+        .repo-name.d-flex.justify-content-between
           %h5.mb-1
-            = app.name
-            = react_component('StatusBadge', { endpoint: api_app_status_path(app) }, tag: :span)
-          %small Updated #{ time_ago_in_words(app.updated_at) } ago
-        %p.mb-1
-          = app.description
+            = repo_name
+      .appscontent
+        - apps.each do |app|
+          %a.list-group-item.list-group-item-action.flex-column.align-items-start.ml-3.apps{ href: app_path(app) }
+            .d-flex.w-100.justify-content-between
+              %h5.mb-1
+                = app.name
+                = react_component('StatusBadge', { endpoint: api_app_status_path(app) }, tag: :span)
+              %small Updated #{ time_ago_in_words(app.updated_at) } ago
+            %p.mb-1
+              = app.description
+


### PR DESCRIPTION
This fixes #9

`/apps` will still show the apps but we'll group them by repository name. You can expand/collapse repositories to see their apps inside.