### PR TITLE
Fix arrow rotation when repository is active

### DIFF
--- a/app/javascript/styles/index.sass
+++ b/app/javascript/styles/index.sass
@@ -189,13 +189,13 @@ pre
       border-left: 5px solid currentColor
       content: ' '
       vertical-align: middle
-  .active
-    .arrow
-      transform: rotate(90deg) translateX(6px) translateY(8px)
-
   .arrow,
   .repo-name
     float: left
+
+.active
+  .arrow
+    transform: rotate(90deg) translateX(6px) translateY(8px)
 
 .apps
   width: auto


### PR DESCRIPTION
I broke the arrow rotation while I was fixing the SASS syntax.