### PR TITLE
Integrate Graylog with Rocksteady

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,5 @@
 NOMAD_API_URI=http://localhost:4646
 ECR_BASE=example.com
+GRAYLOG_API_URI=https://test.com/api
+GRAYLOG_API_USER=test-bot
+GRAYLOG_API_PASSWORD=password

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -1,6 +1,13 @@
 class AppsController < ApplicationController
   def index
-    @repos = App.all.group_by(&:repository_name).sort_by { |repo_name, _| repo_name }
+    respond_to do |format|
+      format.html do
+        @repos = App.all.group_by(&:repository_name).sort_by { |repo_name, _| repo_name }
+      end
+      format.json do
+        render status: :ok, json: App.all
+      end
+    end
   end
 
   def show
@@ -30,7 +37,7 @@ class AppsController < ApplicationController
   end
 
   def create
-    @app = App.new(app_params)
+    @app = AppCreation.new(app_params: app_params, add_stream: add_stream?).create
 
     respond_to do |format|
       format.html do
@@ -53,24 +60,50 @@ class AppsController < ApplicationController
 
   def update
     @app = current_app
+    output = AppUpdate.new(@app, add_stream: add_stream?, update_stream: update_stream?).update(app_params)
 
-    if @app.update(app_params)
-      flash[:notice] = 'App has been updated. You will need to deploy again for any changes to take effect.'
-      redirect_to app_path(@app)
-    else
-      render action: :edit
+    respond_to do |format|
+      format.html do
+        if output[:updated]
+          flash[:notice] = 'App has been updated. You will need to deploy again for any changes to take effect.'
+          flash[:warning] = output[:warning] if output[:warning]
+          redirect_to app_path(@app)
+        else
+          render action: :edit
+        end
+      end
+      format.json do
+        if output[:updated]
+          render status: :ok, json: output[:warning]? { warning: output[:warning], app: @app } : @app
+        else
+          render status: :bad_request, json: "Warning: #{@app.name} could not be updated"
+        end
+      end
     end
   end
 
   def destroy
     @app = current_app
+    output = AppDeletion.new(@app).delete!
 
-    if AppDeletion.new(@app).delete! && @app.destroy
-      flash[:notice] = 'App has been removed from Nomad and deleted'
-      redirect_to action: :index
-    else
-      flash[:error] = 'Could not delete app'
-      render action: :index
+    respond_to do |format|
+      format.html do
+        if output[:deleted] && @app&.destroy
+          flash[:notice] = 'App has been removed from Nomad and deleted'
+          flash[:warning] =  output[:warning] if output[:warning]
+          redirect_to action: :index
+        else
+          flash[:error] = 'Could not delete app'
+          render action: :index
+        end
+      end
+      format.json do
+        if output[:deleted] && @app&.destroy
+          render status: :ok, json: output[:warning] ? { warning: output[:warning], app: 'App deleted' } : 'App Deleted'
+        else
+          render status: :bad_request, json: "Warning: App could not be deleted"
+        end
+      end
     end
   end
 
@@ -88,7 +121,22 @@ class AppsController < ApplicationController
     )
   end
 
+  def graylog_params
+    params.require(:app).permit(
+      :add_graylog_stream,
+      :update_graylog_stream
+    )
+  end
+
   def current_app
     App.find_by(name: params[:id])
+  end
+
+  def add_stream?
+    graylog_params[:add_graylog_stream] == '1'
+  end
+
+  def update_stream?
+    graylog_params[:update_graylog_stream] == '1'
   end
 end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -1,10 +1,15 @@
 class App < ApplicationRecord
+  has_one :graylog_stream, dependent: :destroy
+
   NAME_FORMAT = /\A[a-z0-9\-]+\Z/.freeze
+
+  attr_accessor :validate_stream
 
   validates :name, uniqueness: true, presence: true, format: { with: NAME_FORMAT }
   validates :image_source, inclusion: { in: %w[dockerhub ecr] }
   validates :repository_name, presence: true
   validates :job_spec, presence: true
+  validates_with GraylogValidator, if: :validate_stream
 
   def to_param
     name

--- a/app/models/app_creation.rb
+++ b/app/models/app_creation.rb
@@ -1,0 +1,39 @@
+class AppCreation
+  attr_reader :app, :add_stream
+  private :app, :add_stream
+
+  def initialize(app = nil, options)
+    @app = app || App.new(options[:app_params])
+    @add_stream = options[:add_stream]
+  end
+
+  def create
+    return app unless app.valid?
+
+    add_graylog_stream if add_stream?
+    app
+  end
+
+  def add_graylog_stream
+    app.assign_attributes(validate_stream: true)
+    stream_info = GraylogAPI::StreamConfig.new(app).setup
+    build_associated_stream(stream_info) if stream_info.present?
+    app
+  end
+
+  private
+
+  def add_stream?
+    ENV['GRAYLOG_ENABLED'].present? && add_stream
+  end
+
+  def build_associated_stream(stream_info)
+    app.build_graylog_stream
+    app.graylog_stream.assign_attributes(
+      id: stream_info[:stream_id],
+      name: app.name,
+      rule_value: app.name,
+      index_set_id: stream_info[:index_set_id]
+    )
+  end
+end

--- a/app/models/app_deletion.rb
+++ b/app/models/app_deletion.rb
@@ -1,18 +1,31 @@
 class AppDeletion
-  attr_reader :app
-  private :app
+  attr_reader :app, :result
+  private :app, :result
 
   def initialize(app)
     @app = app
+    @result = {}
   end
 
   def delete!
-    HTTP.delete(url).status.success?
+    delete_graylog_stream if ENV['GRAYLOG_ENABLED'].present?
+
+    result[:deleted] = HTTP.delete(url).status.success?
+    result
   end
 
   private
 
   def url
     ENV.fetch('NOMAD_API_URI') + '/v1/job/' + app.name
+  end
+
+  def delete_graylog_stream
+    stream = app.graylog_stream if app
+    return unless stream
+
+    response = GraylogAPI::StreamConfig.new(app).delete(stream.id)
+
+    result[:warning] = 'Could not delete Graylog stream for App' unless response.successful?
   end
 end

--- a/app/models/app_update.rb
+++ b/app/models/app_update.rb
@@ -1,0 +1,56 @@
+class AppUpdate
+  attr_reader :app, :add_stream, :update_stream, :result
+  private :app, :add_stream, :update_stream, :result
+
+  def initialize(app, options)
+    @app = app
+    @add_stream = options[:add_stream]
+    @update_stream = options[:update_stream]
+    @result = {}
+  end
+
+  def update(app_params)
+    app.assign_attributes(app_params)
+    return app unless app.valid?
+
+    update_graylog if updatable?
+    AppCreation.new(app, add_stream: add_stream).add_graylog_stream if create_or_update_stream?
+
+    result[:updated] = app.save
+    result
+  end
+
+  private
+
+  def add_stream?
+    ENV['GRAYLOG_ENABLED'].present? && add_stream
+  end
+
+  def update_stream?
+    ENV['GRAYLOG_ENABLED'].present? && update_stream
+  end
+
+  def updatable?
+    update_stream? && app.graylog_stream.present?
+  end
+
+  def create_or_update_stream?
+    add_stream? || (update_stream? && app.graylog_stream.blank?)
+  end
+
+  def update_graylog
+    return unless app.repository_name_changed?
+
+    stream_info = GraylogAPI::StreamConfig.new(app).update(app.graylog_stream.id)
+    return update_associated_stream(stream_info) if stream_info.present?
+
+    result[:warning] = 'Graylog stream could not be updated.'
+  end
+
+  def update_associated_stream(stream_info)
+    app.graylog_stream.assign_attributes(
+      index_set_id: stream_info[:index_set_id]
+    )
+    app.graylog_stream.save
+  end
+end

--- a/app/models/graylog_stream.rb
+++ b/app/models/graylog_stream.rb
@@ -1,0 +1,3 @@
+class GraylogStream < ApplicationRecord
+  belongs_to :app
+end

--- a/app/services/graylog_api/client.rb
+++ b/app/services/graylog_api/client.rb
@@ -1,0 +1,48 @@
+require 'http'
+
+module GraylogAPI
+  class Client
+    attr_reader :uri, :user, :password
+    private :uri, :user, :password
+
+    def initialize
+      @uri = ENV['GRAYLOG_API_URI']
+      @user = ENV['GRAYLOG_API_USER']
+      @password = ENV['GRAYLOG_API_PASSWORD']
+    end
+
+    def get(endpoint)
+      rescue_errors { http.get(URI("#{uri}#{endpoint}").to_s) }
+    end
+
+    def post(endpoint, payload)
+      rescue_errors { http.post(URI("#{uri}#{endpoint}").to_s, json: payload) }
+    end
+
+    def put(endpoint, payload, id: nil)
+      rescue_errors { http.put(build_uri(endpoint, id).to_s, json: payload) }
+    end
+
+    def delete(endpoint, id)
+      rescue_errors { http.delete(URI("#{uri}#{endpoint}/#{id}").to_s) }
+    end
+
+    private
+
+    def rescue_errors
+      SuccessResponse.new(yield)
+    rescue HTTP::Error, StandardError => e
+      FailureResponse.new(e)
+    end
+
+    def http
+      HTTP.headers(accept: 'application/json', 'X-Requested-By': 'Graylog API bot').basic_auth(
+        user: user, pass: password
+      )
+    end
+
+    def build_uri(endpoint, id)
+      id ? URI("#{uri}#{endpoint}/#{id}") : URI("#{uri}#{endpoint}")
+    end
+  end
+end

--- a/app/services/graylog_api/failure_response.rb
+++ b/app/services/graylog_api/failure_response.rb
@@ -1,0 +1,18 @@
+module GraylogAPI
+  class FailureResponse
+    attr_reader :error
+    private :error
+
+    def initialize(error)
+      @error = error
+    end
+
+    def body
+      { type: error.class.name, message: error.message, stack_trace: error.full_message }
+    end
+
+    def successful?
+      false
+    end
+  end
+end

--- a/app/services/graylog_api/index_set.rb
+++ b/app/services/graylog_api/index_set.rb
@@ -1,0 +1,40 @@
+module GraylogAPI
+  class IndexSet
+    ENDPOINT = '/system/indices/index_sets'.freeze
+    DEFAULT_INDEX_PREFIX = 'graylog'.freeze
+
+    attr_reader :client, :index_set
+    private :client, :index_set
+
+    def initialize(index_set, client)
+      @client = client
+      @index_set = index_set
+    end
+
+    def read
+      response = client.get(ENDPOINT)
+
+      return unless response.successful?
+
+      set = preferred_set(response)
+
+      return set_id(set) if set.present?
+
+      set_id(default_set(response))
+    end
+
+    private
+
+    def set_id(index_set)
+      index_set&.fetch('id')
+    end
+
+    def preferred_set(response)
+      response.body[:index_sets].find { |set| set['index_prefix'] == index_set || set['title'] == index_set }
+    end
+
+    def default_set(response)
+      response.body[:index_sets].find { |set| set['index_prefix'] == DEFAULT_INDEX_PREFIX }
+    end
+  end
+end

--- a/app/services/graylog_api/role.rb
+++ b/app/services/graylog_api/role.rb
@@ -1,0 +1,37 @@
+module GraylogAPI
+  class Role
+    ENDPOINT = '/roles'.freeze
+
+    attr_reader :role, :client
+    private :role, :client
+
+    def initialize(name, client)
+      @role = { name: name }
+      @client = client
+    end
+
+    def read
+      response = client.get("#{ENDPOINT}/#{role[:name]}")
+      @role = response.body if response.successful?
+      response
+    end
+
+    def update(stream_id)
+      result = read
+      return result unless result.successful?
+
+      update_permissions(stream_id)
+      client.put("#{ENDPOINT}/#{role[:name]}", role)
+    end
+
+    private
+
+    def update_permissions(stream_id)
+      @role[:permissions] = role[:permissions] << permissions_read_syntax(stream_id)
+    end
+
+    def permissions_read_syntax(stream_id)
+      "streams:read:#{stream_id}"
+    end
+  end
+end

--- a/app/services/graylog_api/stream.rb
+++ b/app/services/graylog_api/stream.rb
@@ -1,0 +1,43 @@
+module GraylogAPI
+  class Stream
+    ENDPOINT = '/streams'.freeze
+    START_PATH = '/resume'.freeze
+    MATCH_EXACTLY = 1
+
+    attr_reader :id, :stream, :client
+    private :stream, :client
+
+    def initialize(client, options)
+      title = options[:title]
+      @id = options[:stream_id]
+      @stream = {
+        title: title,
+        description: "Logs for #{title}",
+        rules: [{ type: MATCH_EXACTLY, value: title, field: 'tag', inverted: false }],
+        content_pack: nil,
+        matching_type: 'AND',
+        remove_matches_from_default_stream: true,
+        index_set_id: options[:index_set_id]
+      }
+      @client = client
+    end
+
+    def create
+      response = client.post(ENDPOINT, stream)
+      @id = response.body[:stream_id] if response.successful?
+      response
+    end
+
+    def update
+      client.put(ENDPOINT, stream, id: id)
+    end
+
+    def delete!
+      client.delete(ENDPOINT, id)
+    end
+
+    def start
+      client.post("#{ENDPOINT}/#{id}#{START_PATH}", nil)
+    end
+  end
+end

--- a/app/services/graylog_api/stream_config.rb
+++ b/app/services/graylog_api/stream_config.rb
@@ -1,0 +1,63 @@
+module GraylogAPI
+  class StreamConfig
+    ROLE = 'Dev'.freeze
+
+    attr_reader :app
+    private :app
+
+    def initialize(app)
+      @app = app
+    end
+
+    def setup
+      stream = Stream.new(client, options)
+
+      return unless stream.create.successful?
+
+      stream.start
+      return unless role.update(stream.id).successful?
+
+      {
+        stream_id: stream.id,
+        index_set_id: index_set_id
+      }
+    end
+
+    def update(stream_id)
+      stream = Stream.new(client, options.merge(stream_id: stream_id))
+
+      return unless stream.update.successful?
+
+      {
+        index_set_id: index_set_id
+      }
+    end
+
+    def delete(stream_id)
+      stream = Stream.new(client, options.merge(stream_id: stream_id))
+      stream.delete!
+    end
+
+    def index_set_id
+      @index_set ||= IndexSet.new(index_set, client).read
+    end
+
+    def role
+      @role ||= Role.new(ROLE, client)
+    end
+
+    def client
+      @client ||= Client.new
+    end
+
+    private
+
+    def index_set
+      app.repository_name
+    end
+
+    def options
+      { title: app.name, index_set_id: index_set_id }
+    end
+  end
+end

--- a/app/services/graylog_api/stream_matcher.rb
+++ b/app/services/graylog_api/stream_matcher.rb
@@ -1,0 +1,36 @@
+module GraylogAPI
+  class StreamMatcher
+    def sync_apps_with_existing_streams(all_streams)
+      updated_apps = 0
+
+      App.all.each do |app|
+        next if app.graylog_stream.present?
+
+        app.assign_attributes(validate_stream: true)
+
+        stream_info = all_streams.find do |stream|
+          rule_set = stream['rules'].find { |set| set['value'] == app.name }
+
+          stream['title'] == app.name && rule_set.present?
+        end
+
+        next Rails.logger.warn "Could not find an existing stream for #{app.name}" unless stream_info.present?
+
+        app.build_graylog_stream
+        app.graylog_stream.update(
+          id: stream_info['id'],
+          name: app.name,
+          rule_value: app.name,
+          index_set_id: stream_info['index_set_id']
+        )
+
+        next Rails.logger.warn "Could not update #{app.name}" unless app.save
+        updated_apps += 1
+
+        Rails.logger.info "#{app.name} associated with stream: #{app.graylog_stream.id}"
+      end
+
+      updated_apps
+    end
+  end
+end

--- a/app/services/graylog_api/success_response.rb
+++ b/app/services/graylog_api/success_response.rb
@@ -1,0 +1,21 @@
+module GraylogAPI
+  class SuccessResponse
+    attr_reader :response
+    private :response
+
+    def initialize(response)
+      @response = response
+    end
+
+    def body
+      body = response.parse
+      return {} if body.empty?
+
+      body.transform_keys(&:to_sym)
+    end
+
+    def successful?
+      response.status.success?
+    end
+  end
+end

--- a/app/validators/graylog_validator.rb
+++ b/app/validators/graylog_validator.rb
@@ -1,0 +1,7 @@
+class GraylogValidator < ActiveModel::Validator
+  def validate(record)
+    return true unless ENV['GRAYLOG_ENABLED'].present?
+
+    record.errors.add(:base, 'Could not create Graylog stream') unless record.graylog_stream.present?
+  end
+end

--- a/app/views/apps/_form.html.haml
+++ b/app/views/apps/_form.html.haml
@@ -24,6 +24,20 @@
 
     %small.form-text.text-muted Select whether images will be sourced from Docker Hub or a private ECR repository.
 
+  - if ENV['GRAYLOG_ENABLED'].present? && @app.graylog_stream.blank?
+    .form-group.form-check
+      = f.check_box :add_graylog_stream, checked: false, class: 'form-check-input'
+      = f.label :graylog, "Add stream to Graylog"
+      %small.form-text.text-muted Add a stream to Graylog with permission to read enabled for the Dev usergroup.
+      = link_to '(?) click here for more information', 'https://github.com/PowerRhino/rocksteady/blob/master/README.md#Graylog%20Integration', class: 'small form-text text-muted'
+
+  - if ENV['GRAYLOG_ENABLED'].present? && @app.graylog_stream.present?
+    .form-group.form-check
+      = f.check_box :graylog_stream, checked: true, disabled: true, class: 'form-check-input'
+      = f.hidden_field :update_graylog_stream, value: '1'
+      = f.label :graylog, "A Graylog stream is associated with this app", class: "form-text form-muted"
+      %small.form-text.text-muted Updating the 'Repository name' field will update the associated index_set_id.
+
   .form-group.required
     = f.label :repository_name, "Repository name"
     = f.text_field :repository_name, class: 'form-control'

--- a/db/migrate/20200520104029_create_graylog_streams.rb
+++ b/db/migrate/20200520104029_create_graylog_streams.rb
@@ -1,0 +1,12 @@
+class CreateGraylogStreams < ActiveRecord::Migration[5.1]
+  def change
+    create_table :graylog_streams, id: :string do |t|
+      t.string :name, null: false
+      t.string :rule_value, null: false
+      t.string :index_set_id, null: false
+      t.belongs_to :app, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180710112004) do
+ActiveRecord::Schema.define(version: 20200520104029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,4 +29,15 @@ ActiveRecord::Schema.define(version: 20180710112004) do
     t.index ["name"], name: "index_apps_on_name", unique: true
   end
 
+  create_table "graylog_streams", id: :string, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "rule_value", null: false
+    t.string "index_set_id", null: false
+    t.bigint "app_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["app_id"], name: "index_graylog_streams_on_app_id"
+  end
+
+  add_foreign_key "graylog_streams", "apps"
 end

--- a/lib/tasks/graylog_integration.rake
+++ b/lib/tasks/graylog_integration.rake
@@ -1,0 +1,19 @@
+namespace :graylog do
+  namespace :integration do
+    desc 'Associate all applications with existing Graylog Streams. The task is idempotent'
+    task sync: :environment do
+      abort('GRAYLOG_ENABLED must be present') unless ENV['GRAYLOG_ENABLED'] == 'true'
+
+      client = GraylogAPI::Client.new
+
+      puts "Retrieving all streams for #{ENV['GRAYLOG_API_URI']}"
+      response = client.get('/streams')
+
+      raise response.message unless response.successful?
+
+      updated_apps = GraylogAPI::StreamMatcher.new.sync_apps_with_existing_streams(response.body[:streams])
+
+      Rails.logger.info "Process complete. Updated #{updated_apps} of #{App.count} apps"
+    end
+  end
+end

--- a/spec/models/app_creation_spec.rb
+++ b/spec/models/app_creation_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe AppCreation do
+  subject(:app_creation) { described_class.new(options) }
+  let(:options) { { app_params: app_params, add_stream: add_stream } }
+
+  let(:stream_config_instance) { instance_double(GraylogAPI::StreamConfig) }
+
+  describe 'create' do
+    before do
+      stub_const('ENV', ENV.to_hash.merge('GRAYLOG_ENABLED' => 'true'))
+      allow(GraylogAPI::StreamConfig).to receive(:new).and_return(stream_config_instance)
+    end
+
+    context 'when the app is invalid' do
+      let(:app_params) { { name: 'not valid', repository_name: 'test', job_spec: '{}' } }
+      let(:add_stream) { true }
+
+      it 'does not set up Graylog if the app is invalid' do
+        app_creation.create
+
+        expect(GraylogAPI::StreamConfig).to_not have_received(:new)
+      end
+
+      it 'returns the app instance' do
+        expect(app_creation.create).to be_an(App)
+      end
+    end
+
+    context 'when add_graylog_stream is false' do
+      let(:app_params) { { name: 'name', repository_name: 'test', job_spec: '{}' } }
+      let(:add_stream) { false }
+
+      it 'does not set up Graylog' do
+        app_creation.create
+
+        expect(GraylogAPI::StreamConfig).to_not have_received(:new)
+      end
+
+      it 'returns the app instance' do
+        expect(app_creation.create).to be_an(App)
+      end
+    end
+
+    context 'when add_graylog_stream is true' do
+      let(:app_params) { { name: 'name', repository_name: 'test', job_spec: '{}' } }
+      let(:add_stream) { false }
+
+      it 'sets up Graylog' do
+        allow(stream_config_instance).to receive(:setup)
+
+        app_creation.create
+
+        expect(stream_config_instance).to_not have_received(:setup)
+      end
+
+      it 'returns the app instance' do
+        expect(app_creation.create).to be_an(App)
+      end
+    end
+  end
+
+  describe '#add_graylog_stream' do
+    let(:options) { { app_params: app_params, add_stream: add_stream } }
+    let(:app_params) { { name: 'name', repository_name: 'test', job_spec: '{}' } }
+      let(:add_stream) { true }
+
+    before { stub_const('ENV', ENV.to_hash.merge('GRAYLOG_ENABLED' => 'true')) }
+
+    context 'when the result is successful' do
+      let(:result_stub) {
+        {
+          stream_id: '123',
+          index_set_id: '456'
+        }
+      }
+
+      it 'builds the association' do
+        stream_config_instance = instance_double(GraylogAPI::StreamConfig)
+
+        allow(GraylogAPI::StreamConfig).to receive(:new).and_return(stream_config_instance)
+        allow(stream_config_instance).to receive(:setup).and_return(result_stub)
+
+        app = app_creation.add_graylog_stream
+
+        expect(app.graylog_stream).to_not be_nil
+      end
+    end
+
+    context 'when the result is not successful' do
+      it 'does not build the association' do
+        stream_config_instance = instance_double(GraylogAPI::StreamConfig)
+
+        allow(GraylogAPI::StreamConfig).to receive(:new).and_return(stream_config_instance)
+        allow(stream_config_instance).to receive(:setup)
+
+        app = app_creation.add_graylog_stream
+
+        expect(app.graylog_stream).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/app_update_spec.rb
+++ b/spec/models/app_update_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+RSpec.describe AppUpdate do
+  subject(:app_update) { described_class.new(existing_app, options) }
+  let(:options) { { add_stream: add_stream, update_stream: update_stream } }
+  let(:graylog_stream) { GraylogStream.new(id: '1', name: 'test', rule_value: 'test', index_set_id: '1') }
+
+  def existing_app(stream: graylog_stream)
+    App.create!(
+      { name: 'name', repository_name: 'test', job_spec: 'job {}', graylog_stream: stream }
+    )
+  end
+
+  before { stub_const('ENV', ENV.to_hash.merge('GRAYLOG_ENABLED' => 'true')) }
+
+  describe '#update' do
+    context 'when the app has a stream and update_stream is true' do
+      let(:params) { { name: 'updated', repository_name: 'altmetric' } }
+      let(:add_stream) { false }
+      let(:update_stream) { true }
+
+      it 'updates the index_set_id on the associated stream' do
+        stream_config_instance = instance_double(GraylogAPI::StreamConfig)
+
+        allow(GraylogAPI::StreamConfig).to receive(:new).and_return(stream_config_instance)
+        allow(stream_config_instance).to receive(:update).and_return({index_set_id: '456'})
+
+        app_update.update(params)
+
+        app = App.find_by(name: 'updated')
+
+        expect(app.graylog_stream.index_set_id).to eq('456')
+      end
+    end
+
+    context 'when the app has a stream and update_stream is false' do
+      let(:params) { { name: 'valid' } }
+      let(:add_stream) { false }
+      let(:update_stream) { false }
+
+      it 'does not update the associated stream' do
+        allow(GraylogAPI::StreamConfig).to receive(:new)
+
+        app_update.update(params)
+
+        expect(GraylogAPI::StreamConfig).to_not have_received(:new)
+      end
+    end
+
+    context 'when the app has a stream but the stream cannot be updated' do
+      let(:params) { { name: 'valid', repository_name: 'altmetric' } }
+      let(:add_stream) { false }
+      let(:update_stream) { true }
+
+      it 'returns a message to be displayed' do
+        stream_config_instance = instance_double(GraylogAPI::StreamConfig)
+
+        allow(GraylogAPI::StreamConfig).to receive(:new).and_return(stream_config_instance)
+        allow(stream_config_instance).to receive(:update)
+
+        result = app_update.update(params)
+
+        expect(result[:warning]).to eq('Graylog stream could not be updated.')
+      end
+    end
+
+    context 'when the app has a stream but repository_name has not changed' do
+      let(:params) { { name: 'valid' } }
+      let(:add_stream) { false }
+      let(:update_stream) { true }
+
+      it 'does not update the stream' do
+        allow(GraylogAPI::StreamConfig).to receive(:new)
+
+        app_update.update(params)
+
+        expect(GraylogAPI::StreamConfig).to_not have_received(:new)
+      end
+    end
+
+    context 'when the app does not have a stream and add_stream is true' do
+      let(:params) { { name: 'valid' } }
+      let(:add_stream) { true }
+      let(:update_stream) { false }
+      let(:result_stub) {
+        {
+          stream_id: '123',
+          index_set_id: '456'
+        }
+      }
+
+      it 'adds the associated stream to the app' do
+        stream_config_instance = instance_double(GraylogAPI::StreamConfig)
+
+        allow(GraylogAPI::StreamConfig).to receive(:new).and_return(stream_config_instance)
+        allow(stream_config_instance).to receive(:setup).and_return(result_stub)
+        app = existing_app(stream: false)
+        described_class.new(app, options).update(params)
+
+        expect(app.graylog_stream).to be_present
+      end
+    end
+
+    context 'when the app does not have a stream and update_stream is false but update_stream is true' do
+      let(:params) { { name: 'valid' } }
+      let(:add_stream) { false }
+      let(:update_stream) { true }
+      let(:result_stub) {
+        {
+          stream_id: '123',
+          index_set_id: '456'
+        }
+      }
+
+      it 'adds the associated stream to the app' do
+        stream_config_instance = instance_double(GraylogAPI::StreamConfig)
+
+        allow(GraylogAPI::StreamConfig).to receive(:new).and_return(stream_config_instance)
+        allow(stream_config_instance).to receive(:setup).and_return(result_stub)
+        app = existing_app(stream: false)
+        described_class.new(app, options).update(params)
+
+        expect(app.graylog_stream).to be_present
+      end
+    end
+
+    context 'when the app is invalid' do
+      let(:params) { { name: 'not valid' } }
+      let(:update_stream) { true }
+      let(:add_stream) { false }
+
+      it 'does not update the associated stream' do
+        allow(GraylogAPI::StreamConfig).to receive(:new)
+
+        app_update.update(params)
+
+        expect(GraylogAPI::StreamConfig).to_not have_received(:new)
+      end
+    end
+  end
+end

--- a/spec/services/graylog_api/client_spec.rb
+++ b/spec/services/graylog_api/client_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+RSpec.describe GraylogAPI::Client do
+  subject(:client) { described_class.new }
+  let(:url) { "#{ENV['GRAYLOG_API_URI']}/endpoint" }
+
+  before do
+    stub_const('ENV', ENV.to_hash.merge('GRAYLOG_ENABLED' => 'true'))
+  end
+
+  it 'is authenticated' do
+    authenticated_stub = stub_request(:any, url).with(
+      basic_auth: [ENV['GRAYLOG_API_USER'], ENV['GRAYLOG_API_PASSWORD']]
+    )
+    client.get('/endpoint')
+    expect(authenticated_stub).to have_been_requested.once
+  end
+
+  it 'sends the right headers' do
+    headers_stub = stub_request(:any, url).with(
+      headers: {Accept: 'application/json', 'X-Requested-By': 'Graylog API bot' }
+    )
+    client.post('/endpoint', 'irrelevant')
+    expect(headers_stub).to have_been_requested.once
+  end
+
+  context 'when success' do
+    describe '#get' do
+      before do
+        stub_request(:get, url).to_return(
+          status: 200, body: { key: 'value' }.to_json, headers: { 'Content-Type': 'application/json' }
+        )
+      end
+
+      it 'is successful' do
+        expect(client.get('/endpoint')).to be_successful
+      end
+
+      it 'can parse the response' do
+        expect(client.get('/endpoint').body).to eq(key: 'value')
+      end
+    end
+
+    describe '#post' do
+      def stub_post_with(status:, body:)
+        stub_request(:post, url).to_return(
+          status: status, body: body.to_json, headers: { 'Content-Type': 'application/json' }
+        )
+      end
+
+      it 'is successful with payload' do
+        stub_post_with(status: 201, body: { key: 'value' })
+        expect(client.post('/endpoint', pay: 'load')).to be_successful
+      end
+
+      it 'is successful with no payload' do
+        stub_post_with(status: 204, body: '')
+        expect(client.post('/endpoint', nil)).to be_successful
+      end
+
+      it 'can parse the response with payload' do
+        stub_post_with(status: 201, body: { key: 'value' })
+        response = client.post('/endpoint', pay: 'load')
+        expect(response.body).to eq(key: 'value')
+      end
+
+      it 'can parse the response with no payload' do
+        stub_post_with(status: 201, body: '')
+        response = client.post('/endpoint', nil)
+        expect(response.body).to be_empty
+      end
+    end
+
+    describe '#put' do
+      before do
+        stub_request(:put, url).to_return(
+          status: 200, body: { key: 'value' }.to_json, headers: { 'Content-Type': 'application/json' }
+        )
+      end
+
+      it 'is successful' do
+        expect(client.put('/endpoint', pay: 'load')).to be_successful
+      end
+
+      it 'can parse the response' do
+        response = client.put('/endpoint', pay: 'load')
+        expect(response.body).to eq(key: 'value')
+      end
+
+      it 'can receive an optional id' do
+        stub_request(:put, "#{url}/123")
+
+        response = client.put('/endpoint', { pay: 'load' }, id: '123')
+        expect(WebMock).to have_requested(:put, 'https://test.com/api/endpoint/123')
+      end
+    end
+
+    describe '#delete' do
+      let(:delete_url) { "#{url}/#{id}" }
+      let(:id) { '123456' }
+
+      before do
+        stub_request(:delete, delete_url).to_return(
+          status: 204, body: '', headers: { 'Content-Type': 'application/json' }
+        )
+      end
+
+      it 'is successful' do
+        expect(client.delete('/endpoint', id)).to be_successful
+      end
+    end
+  end
+
+  context 'when failure' do
+    before { stub_request(:any, url).to_timeout }
+
+    it 'is unsuccessful' do
+      expect(client.get('/endpoint')).to_not be_successful
+    end
+
+    it 'returns the type of error' do
+      expect(client.get('/endpoint').body[:type]).to eq('HTTP::TimeoutError')
+    end
+
+    it 'returns the error message' do
+      expect(client.post('/endpoint', pay: 'load').body[:message]).to include('timed out')
+    end
+
+    it 'returns the full error message' do
+      expect(client.put('/endpoint', pay: 'load').body[:stack_trace]).to include('1: from')
+    end
+
+    it 'returns the type of error for 3xx, 4xx and 5xx codes' do
+      stub_request(:get, url).to_return(
+        status: 404, body: { type: 'ApiError', message: 'HTTP 404 Not Found' }.to_json,
+        headers: { 'Content-Type': 'application/json' }
+      )
+      expect(client.get('/endpoint').body[:type]).to eq('ApiError')
+    end
+  end
+end

--- a/spec/services/graylog_api/failure_response_spec.rb
+++ b/spec/services/graylog_api/failure_response_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe GraylogAPI::FailureResponse do
+  subject(:failure_response) { described_class.new(error_stub) }
+
+  let(:error_stub) {
+    OpenStruct.new(
+      class: OpenStruct.new(name: 'ErrorClass'),
+      message: 'Something went wrong',
+      full_message: 'Something went very wrong'
+    )
+  }
+
+  describe '#body' do
+    it 'returns the data with symbolized keys' do
+      expect(failure_response.body).to eq({
+        message: 'Something went wrong',
+        stack_trace: 'Something went very wrong',
+        type: 'OpenStruct'
+      })
+    end
+  end
+
+  describe '#successful?' do
+    it 'returns false' do
+      expect(failure_response.successful?).to be_falsey
+    end
+  end
+end

--- a/spec/services/graylog_api/index_set_spec.rb
+++ b/spec/services/graylog_api/index_set_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe GraylogAPI::IndexSet do
+  subject(:index_set_instance) { described_class.new(index_set, GraylogAPI::Client.new) }
+  let(:headers) { {'Content-Type' => 'application/json'} }
+
+  describe '#read' do
+    context 'when the index_set is available as index_prefix' do
+      let(:index_set) { 'requested_index_set' }
+
+      it 'returns the id' do
+        stub_request(:get, 'https://test.com/api/system/indices/index_sets')
+          .to_return(status: 200, body: response_body('index_prefix').to_json, headers: headers)
+
+        expect(index_set_instance.read).to eq 'requested_id'
+      end
+    end
+
+    context 'when the index_set is available as title' do
+      let(:index_set) { 'requested_index_set' }
+
+      it 'returns the id' do
+        stub_request(:get, 'https://test.com/api/system/indices/index_sets')
+          .to_return(status: 200, body: response_body('title').to_json, headers: headers)
+
+        expect(index_set_instance.read).to eq 'requested_id'
+      end
+    end
+
+    context 'when the index_set is not available' do
+      let(:index_set) { 'not_available' }
+
+      it 'returns the default' do
+        stub_request(:get, 'https://test.com/api/system/indices/index_sets')
+          .to_return(status: 200, body: response_body('invalid').to_json, headers: headers)
+
+        expect(index_set_instance.read).to eq 'default_set_id'
+      end
+    end
+
+    context 'when the response is not successful' do
+      let(:index_set) { 'not_available' }
+
+      it 'return nil' do
+        stub_request(:get, 'https://test.com/api/system/indices/index_sets')
+          .to_return(status: 400, body: '', headers: headers)
+
+        expect(index_set_instance.read).to be_nil
+      end
+    end
+  end
+
+  def response_body(field)
+    {
+      index_sets: [
+        {
+          field => 'requested_index_set',
+          'id'  => 'requested_id'
+        },
+        {
+          'index_prefix' => 'graylog',
+          'id'  => 'default_set_id'
+        }
+      ]
+    }
+  end
+end

--- a/spec/services/graylog_api/role_spec.rb
+++ b/spec/services/graylog_api/role_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe GraylogAPI::Role do
+  subject(:role) { described_class.new('Name', GraylogAPI::Client.new) }
+
+  let(:url) { "#{ENV['GRAYLOG_API_URI']}#{described_class::ENDPOINT}/Name" }
+
+  context 'when success' do
+    it 'reads a role' do
+      read_role_stub
+      expect(role.read).to be_successful
+    end
+
+    it 'updates a role' do
+      read_role_stub
+      update_role_stub
+      expect(role.update('new_stream_id')).to be_successful
+    end
+
+    def update_role_stub
+      body = JSON.parse(read_role_stub.response.body).transform_keys(&:to_sym)
+      body[:permissions] = ['streams:read:existing_stream_id', 'streams:read:new_stream_id']
+      stub_request(:put, url).to_return(
+        status: 200, body: body.to_json, headers: { 'Content-Type': 'application/json' }
+      )
+    end
+  end
+
+  context 'when failure' do
+    it 'does not read role' do
+      stub_request(:get, url).to_timeout
+      expect(role.read).to_not be_successful
+    end
+
+    it 'does not update role if read fails' do
+      stub_request(:get, url).to_timeout
+      stub_request(:put, url).to_return(status: 200)
+      expect(role.update('new_stream_id')).to_not be_successful
+    end
+
+    it 'does not update role if read succeeds but update fails' do
+      body = JSON.parse(read_role_stub.response.body).transform_keys(&:to_sym)
+      body[:permissions] = ['streams:read:existing_stream_id', 'streams:read:new_stream_id']
+      stub_request(:put, url).with(body: body).to_timeout
+      expect(role.update('new_stream_id')).to_not be_successful
+    end
+  end
+
+  def read_role_stub
+    body = {
+      name: 'Name',
+      description: 'Description',
+      permissions: ['streams:read:existing_stream_id'],
+      read_only: false
+    }
+    stub_request(:get, url).to_return(
+      status: 200, body: body.to_json, headers: { 'Content-Type': 'application/json' }
+    )
+  end
+end

--- a/spec/services/graylog_api/stream_config_spec.rb
+++ b/spec/services/graylog_api/stream_config_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe GraylogAPI::StreamConfig do
+  subject(:stream_config) { described_class.new(app) }
+
+  let(:app) { instance_double('App', { repository_name: 'test', name: 'app name'}) }
+  let(:index_sets) {
+    {
+      index_sets: [
+        {'id' => '123', 'index_prefix' => 'graylog'}
+      ]
+    }
+  }
+  let(:headers) { {'Content-Type' => 'application/json'} }
+
+  describe '#setup' do
+    let(:stream) { {stream_id: '999'} }
+    let(:role) {
+      {
+        name: 'Dev',
+        description: 'Altmetric developers',
+        permissions: [
+          'streams:read:777'
+        ]
+      }
+    }
+
+    context 'when all the requests are successful' do
+      before do
+        get_index_sets_stub
+        stream_stub(verb: :post, response: stream)
+        streams_resume_stub
+        role_update_stub(response: role)
+        role_update_stub(verb: :put)
+      end
+
+      it 'returns a hash with the stream_id and index_set_id' do
+        expect(stream_config.setup[:stream_id]).to be_present
+      end
+    end
+
+    context 'when the stream is not created successfully cause of a bad response' do
+        before do
+          get_index_sets_stub(status: 400)
+          stream_stub(verb: :post, status: 400)
+        end
+
+      it 'returns nil' do
+        expect(stream_config.setup).to_not be_present
+      end
+    end
+
+    context 'when the stream is not created successfully cause of a network error' do
+      before do
+        get_index_sets_stub
+        stub_request(:post, 'https://test.com/api/streams')
+          .to_raise(HTTP::Error)
+      end
+
+      it 'returns nil' do
+        expect(stream_config.setup).to_not be_present
+      end
+    end
+  end
+
+  describe '#delete' do
+    let(:stream) { GraylogStream.new(id: '123') }
+    let(:app) { App.create(name: 'app name', repository_name: 'test', job_spec: '{}', graylog_stream: stream) }
+
+    before { get_index_sets_stub }
+
+    context 'when the request is successful' do
+      before { stream_stub(verb: :delete, id: '123') }
+
+      it 'removes the stream from the index and returns a result object' do
+        expect(described_class.new(app).delete(stream.id)).to be_successful
+      end
+    end
+
+    context 'when the request is not successful' do
+      before { stream_stub(verb: :delete, status: 400, id: '123') }
+
+      it 'returns a response object' do
+        expect(described_class.new(app).delete(stream.id)).to_not be_successful
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:stream) { GraylogStream.new(id: '123') }
+    let(:app) { App.create(name: 'app name', repository_name: 'test', job_spec: '{}', graylog_stream: stream) }
+
+    before { get_index_sets_stub }
+
+    context 'when the request is successful' do
+      before { stream_stub(verb: :put, id: '123') }
+
+      it 'updates the stream and returns the index_set_id' do
+        expect(described_class.new(app).update(stream.id)).to eq({index_set_id: '123'})
+      end
+    end
+
+    context 'when the request is not successful' do
+      before { stream_stub(verb: :put, status: 400, id: '123') }
+
+      it 'returns nil' do
+        expect(described_class.new(app).update(stream.id)).to_not be_present
+      end
+    end
+  end
+
+  def get_index_sets_stub(status: 200)
+    stub_request(:get, 'https://test.com/api/system/indices/index_sets')
+      .to_return(status: status, body: index_sets.to_json, headers: headers)
+  end
+
+  def stream_stub(verb:, status: 200, response: '', id: nil)
+    url = id ? "https://test.com/api/streams/#{id}" : "https://test.com/api/streams"
+
+    stub_request(verb, url)
+      .to_return(status: status, body: response.to_json, headers: headers)
+  end
+
+  def streams_resume_stub
+    stub_request(:post, 'https://test.com/api/streams/999/resume')
+      .to_return(status: 200, body: ''.to_json, headers: headers)
+  end
+
+  def role_update_stub(verb: :get, status: 200, response: '')
+    stub_request(verb, 'https://test.com/api/roles/Dev')
+      .to_return(status: status, body: response.to_json, headers: headers)
+  end
+end

--- a/spec/services/graylog_api/stream_matcher_spec.rb
+++ b/spec/services/graylog_api/stream_matcher_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe GraylogAPI::StreamMatcher do
+  subject(:updater) { described_class.new }
+
+  let(:graylog_stream) { GraylogStream.new(id: '1', name: 'app-title-1', rule_value: 'app-title-1', index_set_id: '1') }
+  let(:all_streams) {
+    [
+      {
+        "id"=>"stream_id_1",
+        "description"=>"some-description",
+        "rules"=>
+         [{"field"=>"tag", "stream_id"=>"stream_id_1", "description"=>"", "id"=>"some_id", "type"=>6, "inverted"=>false, "value"=>"app-title-1"},
+          {"field"=>"tag", "stream_id"=>"stream_id_1", "description"=>"", "id"=>"some_id", "type"=>6, "inverted"=>true, "value"=>"app-title-1-migrations"}],
+        "title"=>"app-title-1",
+        "index_set_id"=>"index_set_id_1",
+      },
+      {
+        "id"=>"stream_id_2",
+        "description"=>"some-description",
+        "rules"=>
+         [{"field"=>"tag", "stream_id"=>"stream_id_2", "description"=>"", "id"=>"some_id", "type"=>6, "inverted"=>false, "value"=>"app-title-2"},
+          {"field"=>"tag", "stream_id"=>"stream_id_2", "description"=>"", "id"=>"some_id", "type"=>6, "inverted"=>true, "value"=>"app-title-2-migrations"}],
+        "title"=>"app-title-2",
+        "index_set_id"=>"index_set_id_2",
+      }
+    ]
+  }
+
+  def existing_app(name: 'app-title-1', stream: graylog_stream)
+    App.create!(
+      { name: name, repository_name: 'test', job_spec: 'job {}', graylog_stream: stream }
+    )
+  end
+
+  describe '#sync_apps_with_existing_streams' do
+    context 'when a graylog_stream association is already present on all apps' do
+      it 'returns 0' do
+        existing_app
+
+        expect(updater.sync_apps_with_existing_streams(all_streams)).to eq(0)
+      end
+    end
+
+    context 'when all apps have no association and the streams are present in Graylog' do
+      it 'returns the number of updated apps' do
+        existing_app(stream: nil)
+        existing_app(name: 'app-title-2', stream: nil)
+
+        expect(updater.sync_apps_with_existing_streams(all_streams)).to eq(2)
+      end
+
+      it 'associates all apps with graylog_streams' do
+        existing_app(stream: nil)
+        existing_app(name: 'app-title-2', stream: nil)
+
+        updater.sync_apps_with_existing_streams(all_streams)
+
+        stream_ids = App.all.map {|app| app.graylog_stream.id }
+
+        expect(stream_ids).to match_array(['stream_id_1', 'stream_id_2'])
+      end
+    end
+
+    context 'when all apps have no association and some streams are present in Graylog' do
+      it 'returns the number of updated apps' do
+        existing_app(stream: nil)
+        existing_app(name: 'not-present-1', stream: nil)
+
+        expect(updater.sync_apps_with_existing_streams(all_streams)).to eq(1)
+      end
+
+      it 'logs a warning' do
+        allow(Rails.logger).to receive(:warn)
+
+        existing_app(stream: nil)
+        existing_app(name: 'not-present-1', stream: nil)
+
+        updater.sync_apps_with_existing_streams(all_streams)
+
+        expect(Rails.logger).to have_received(:warn).with(
+          'Could not find an existing stream for not-present-1'
+        )
+      end
+    end
+  end
+end

--- a/spec/services/graylog_api/stream_spec.rb
+++ b/spec/services/graylog_api/stream_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe GraylogAPI::Stream do
+  subject(:stream) { described_class.new(GraylogAPI::Client.new, options) }
+
+  let(:options) { { title: 'a title', index_set_id: '2cf6d1dd4abcfd87322378f2' } }
+  let(:url) { "#{ENV['GRAYLOG_API_URI']}#{described_class::ENDPOINT}" }
+
+  it 'does not have an id before creation' do
+    expect(stream.id).to be_nil
+  end
+
+  context 'when success' do
+    before { stub_stream_creation }
+
+    it 'creates a stream' do
+      expect(stream.create).to be_successful
+    end
+
+    context 'when passed an optional stream_id' do
+      subject(:stream) { described_class.new(GraylogAPI::Client.new, options.merge(stream_id: '2')) }
+
+      it 'it can delete a stream' do
+        stub_stream_deletion
+        expect(stream.delete!).to be_successful
+      end
+
+      it 'it can update a stream' do
+        stub_stream_update
+        expect(stream.update).to be_successful
+      end
+    end
+
+    it 'has an id' do
+      stream.create
+      expect(stream.id).to eq('1')
+    end
+
+    it 'starts a created stream' do
+      stream.create
+
+      stub_stream_start
+      expect(stream.start).to be_successful
+    end
+
+    it 'can create several streams with the same title' do
+      stub_request(:post, url).to_return(
+        { status: 201, body: { stream_id: '1' }.to_json, headers: { 'Content-Type': 'application/json' } },
+        { status: 201, body: { stream_id: '2' }.to_json, headers: { 'Content-Type': 'application/json' } }
+      )
+      stream.create
+      stream.create
+
+      expect(stream.id).to eq('2')
+    end
+
+    def stub_stream_start
+      stub_request(:post, "#{url}/1#{described_class::START_PATH}").to_return(status: 204, body: '')
+    end
+  end
+
+  context 'when failure' do
+    before { stub_request(:post, url).to_timeout }
+
+    it 'does not create stream' do
+      expect(stream.create).to_not be_successful
+    end
+
+    it 'does not have an id' do
+      stream.create
+      expect(stream.id).to be_nil
+    end
+
+    it 'does not start a stream that was not created' do
+      stream.create
+
+      stub_stream_start_when_no_id
+      expect(stream.start).to_not be_successful
+    end
+
+    it 'does not start a created stream if can not resume' do
+      stub_stream_creation
+      stream.create
+
+      stub_request(:post, "#{url}/1#{described_class::START_PATH}").to_timeout
+      expect(stream.start).to_not be_successful
+    end
+
+    def stub_stream_start_when_no_id
+      stub_request(:post, "#{url}/#{described_class::START_PATH}").to_return(
+        status: 404, body: { type: 'ApiError', message: 'HTTP 404 Not Found'}.to_json
+      )
+    end
+  end
+
+  def stub_stream_creation
+    stub_request(:post, url).to_return(
+      status: 201, body: { stream_id: '1' }.to_json, headers: { 'Content-Type': 'application/json' }
+    )
+  end
+
+  def stub_stream_deletion
+    stub_request(:delete, "#{url}/2").to_return(
+      status: 201, body: '', headers: { 'Content-Type': 'application/json' }
+    )
+  end
+
+  def stub_stream_update
+    stub_request(:put, "#{url}/2").to_return(
+      status: 201, body: {data: 'updated stream data'}.to_json, headers: { 'Content-Type': 'application/json' }
+    )
+  end
+end

--- a/spec/services/graylog_api/success_response_spec.rb
+++ b/spec/services/graylog_api/success_response_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe GraylogAPI::SuccessResponse do
+  subject(:successful_response) { described_class.new(response_stub) }
+
+  describe '#body' do
+    context 'when the body is not empty' do
+      let(:response_stub) { OpenStruct.new(parse: {'data' => 'data'}) }
+
+      it 'returns the data with symbolized keys' do
+        expect(successful_response.body).to eq({data: 'data'})
+      end
+    end
+
+    context 'when the body is empty' do
+      let(:response_stub) { OpenStruct.new(parse: '') }
+
+      it 'returns an empty hash' do
+        expect(successful_response.body).to eq(Hash.new)
+      end
+    end
+  end
+
+  describe '#successful?' do
+    context 'when the response status is success' do
+      let(:response_stub) { OpenStruct.new(status: OpenStruct.new(success?: true)) }
+
+      it 'returns true ' do
+        expect(successful_response.successful?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
We are currently working on an internal tooling project that will automate our processes and one of the requirements is to have Graylog streams created programmatically.
The aim of this PR is to provide an MVP that covers all initial requirements, leaving it open for future customisations if needed (inevitably opinionated, but open for customisation)
Some of the code was re-used from an internal utility application (`Stream`, `Role` and `Client` specifically)
## Scenarios
- The aim is to provide a backward compatible implementation. Nothing will change if `GRAYLOG_ENABLED` is not present. 
- If `GRAYLOG_ENABLED` is present a checkbox will be available in the 'new app' form and a [Graylog Stream](https://docs.graylog.org/en/3.2/pages/streams.html) will be created / updated if checked. 
- An application without a stream can still be created by unticking the box 
- An existing application can have a stream added if updated via UI or if `:update_graylog_stream` is present in the payload when sending a JSON to Rocksteady 
- If the box is ticked and an error occurs while creating the stream the App is not created and an error is displayed instead. An App can still be updated or deleted if something goes wrong while updating / deleting the Stream, but a warning is displayed. 

### API

The behaviour is the same when requests are in `json` format